### PR TITLE
Allow ERB in config files

### DIFF
--- a/lib/eye/patch/application.rb
+++ b/lib/eye/patch/application.rb
@@ -21,7 +21,7 @@ module Eye::Patch
     end
 
     def parse_configuration
-      @config = (@settings[:application] || {}).merge(
+      @config = @settings.fetch(:application, {}).merge(
         name: @settings[:name],
         notify: notifications,
         triggers: triggers,

--- a/lib/eye/patch/settings.rb
+++ b/lib/eye/patch/settings.rb
@@ -1,15 +1,15 @@
+require "erb"
+require "forwardable"
 require_relative "value_parser"
 
 module Eye::Patch
 
   class Settings
+    extend Forwardable
+    def_delegators :parsed, :[], :fetch
 
     def initialize(filename)
-      @settings = YAML.load(File.open(filename))
-    end
-
-    def [](value)
-      parsed[value]
+      @settings = YAML.load(ERB.new(File.read(filename)).result)
     end
 
     private

--- a/test/lib/eye/patch/settings_test.rb
+++ b/test/lib/eye/patch/settings_test.rb
@@ -1,0 +1,15 @@
+require_relative "../../../test_helper"
+require "tempfile"
+
+module Eye
+  module Patch
+    describe Settings do
+      it "evaluates the yaml as ERB" do
+        file = Tempfile.new("yaml")
+        file.write("sum: <%= 1 + 2 %>")
+        file.close
+        assert_equal 3, Settings.new(file.path)[:sum]
+      end
+    end
+  end
+end


### PR DESCRIPTION
I don't know if this is even useful. I wrote it with the idea that it could help pull in settings from other sources (so that you don't have to repeat junk like AWS keys), but then I realized that maybe this wouldn't really work towards that end since eye won't have loaded the application code where it would be easiest to reference those shared settings from.
