### PR TITLE
Depend on Eye ~>0.5

### DIFF
--- a/eye-patch.gemspec
+++ b/eye-patch.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^test/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "eye"
+  spec.add_dependency "eye", "~> 0.5"
   spec.add_dependency "chronic_duration"
 
   spec.add_development_dependency "bundler", "~> 1.3"


### PR DESCRIPTION
Eye::Patch uses Eye::Cli which was not introduced until
Eye v0.5.0, so we've got to set the minimum version here.
