### PR TITLE
make aws credentials and region optional for aws_sdk integration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,10 @@ Note that SES support will only be provided if a necessary gem is installed on t
           contact: test+admin@example.com
           config:
             from: eye+notifications@example.com
-            region: us-east-1 # NOTE: the 'region' is required for aws-sdk
-            access_key_id: Your+AWS+Access+Key+ID
-            secret_access_key: Your+AWS+Secret+Access+Key
+            region: us-east-1 # optional
+            # NOTE: the default region is us-east-1. It can be overriden.
+            access_key_id: Your+AWS+Access+Key+ID # optional
+            secret_access_key: Your+AWS+Secret+Access+Key # optional
 
 
 In either case above, an example notification block for monitored process:

--- a/lib/eye/notify/awssdk.rb
+++ b/lib/eye/notify/awssdk.rb
@@ -4,15 +4,18 @@ require "aws-sdk-core/ses"
 module Eye
   class Notify
     class AWSSDK < Eye::Notify
-      param :region, String, true
-      param :access_key_id, String, true
-      param :secret_access_key, String, true
+      param :region, String
+      param :access_key_id, String
+      param :secret_access_key, String
       param :from, String, true
 
       def execute
-        client = Aws::SES::Client.new(
-          region: region,
-          credentials: Aws::Credentials.new(access_key_id, secret_access_key))
+        options = { region: "us-east-1" } # default to us-east-1
+        options[:region] = region if region
+        if access_key_id && secret_access_key
+          options[:credentials] = Aws::Credentials.new(access_key_id, secret_access_key)
+        end
+        client = Aws::SES::Client.new(options)
         client.send_email(message)
       end
 


### PR DESCRIPTION
Based upon https://github.com/tablexi/eye-patch/pull/7

This allows the eye.yml to optionally specify region, and access key credentials.