### PR TITLE
Expose proper value for `__FILE__` in config ERB

### DIFF
--- a/lib/eye/patch/settings.rb
+++ b/lib/eye/patch/settings.rb
@@ -9,7 +9,11 @@ module Eye::Patch
     def_delegators :parsed, :[], :fetch
 
     def initialize(filename)
-      @settings = YAML.load(ERB.new(File.read(filename)).result)
+      file = File.new(filename)
+      erb = ERB.new(file.read)
+      erb.filename = file.path
+
+      @settings = YAML.load(erb.result)
     end
 
     private

--- a/test/lib/eye/patch/settings_test.rb
+++ b/test/lib/eye/patch/settings_test.rb
@@ -10,6 +10,14 @@ module Eye
         file.close
         assert_equal 3, Settings.new(file.path)[:sum]
       end
+
+      it "exposes the config file's path within ERB" do
+        file = Tempfile.new("yaml")
+        file.write("working_dir: <%= __FILE__ %>/..")
+        file.close
+
+        assert_equal File.join(file.path, ".."), Settings.new(file.path)[:working_dir]
+      end
     end
   end
 end

--- a/test/lib/eye/patch/settings_test.rb
+++ b/test/lib/eye/patch/settings_test.rb
@@ -16,7 +16,10 @@ module Eye
         file.write("working_dir: <%= __FILE__ %>/..")
         file.close
 
-        assert_equal File.join(file.path, ".."), Settings.new(file.path)[:working_dir]
+        assert_equal(
+          File.join(file.path, ".."),
+          Settings.new(file.path)[:working_dir],
+        )
       end
     end
   end


### PR DESCRIPTION
Wouldn’t it be great if we could dynamically figure out the working
directory from the config file’s location? By setting the `filename`
attribute of our ERB object, we can now accomplish exactly that goal!

h/t to @mlineen for banging his head against this problem long enough
to inspire a fix.