### PR TITLE
Properly parse child-level checks on load

### DIFF
--- a/lib/eye/patch/process_set.rb
+++ b/lib/eye/patch/process_set.rb
@@ -41,6 +41,15 @@ module Eye::Patch
 
       self[name][:triggers] = self[name][:triggers].merge(monitors[:triggers])
       self[name][:checks] = self[name][:checks].merge(monitors[:checks])
+
+      return unless config[:monitor_children]
+      return unless config[:monitor_children][:checks]
+
+      monitor_options = OptionSet.new(
+        Eye::Checker,
+        config[:monitor_children][:checks])
+
+      self[name][:monitor_children][:checks] = monitor_options
     end
 
     def indexed_config(config, index)

--- a/test/fixtures/test.yml
+++ b/test/fixtures/test.yml
@@ -34,6 +34,13 @@ processes:
       start_command: bundle exec my-process
       pid_file: tmp/pids/my-process.pid
       stdall: log/my-process.log
+      monitor_children:
+        checks:
+          - name: memory
+            config:
+              times: 2
+              every: 10 seconds
+              below: 512 megabytes
   - name: first-grouped-process
     group: my-group
     config:

--- a/test/lib/eye/patch_test.rb
+++ b/test/lib/eye/patch_test.rb
@@ -76,6 +76,21 @@ describe Eye::Patch do
       end
     end
 
+    it "loads children-level checks" do
+      process = @application[:groups]["__default__"][:processes].values.first
+      process_config = @original["processes"].detect do |p|
+        p["name"] == process[:name]
+      end
+      check = process_config["config"]["monitor_children"]["checks"].first
+      parsed_check = process[:monitor_children][:checks][check["name"].to_sym]
+
+      %w(times every below).each do |setting|
+        assert_equal(
+          Eye::Patch::ValueParser.parse(check["config"][setting]),
+          parsed_check[setting.to_sym])
+      end
+    end
+
     it "passes application configurations down to processes" do
       process = @application[:groups]["__default__"][:processes].values.first
       assert_equal @application[:triggers], process[:triggers]


### PR DESCRIPTION
Eye supports child-level monitoring checks like so:

```ruby
monitor_children do
  restart_command 'kill -2 {PID}' # for this child process
  check :memory, below: 300.megabytes, times: 3
end
```

In order to support this functionality, we need to properly parse checks within the `monitor_children` configuration to ensure that the expected `type` is assigned.