### PR TITLE
Upgrade to version of eye that doesn't fail compilation.

### DIFF
--- a/eye-patch.gemspec
+++ b/eye-patch.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.4.2"
 
   spec.add_dependency "chronic_duration"
-  spec.add_dependency "eye", ">= 0.6.2"
+  spec.add_dependency "eye", ">= 0.10.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "minitest"


### PR DESCRIPTION
Since using a a new version of GCC we started getting an error described
in https://github.com/kostya/eye/wiki/Dealing-with-%22server-has-not-started-in-15-seconds%22#sigarso-undefined-symbol-sigar_skip_token
The solution is to upgrade to the latest version of eye

See https://tablexi.slack.com/archives/C02HB2QML/p1527601540000070 for details

### Notes for reviewer

- First PR to the Gem
- I poked the gem around with a stick, but not sure of something might break.
- Anything else? 