### PR TITLE
add :eye_bin to :chruby_map_bins to add compatibility with chruby

### DIFF
--- a/lib/eye/patch/capistrano3.rb
+++ b/lib/eye/patch/capistrano3.rb
@@ -7,6 +7,7 @@ namespace :load do
     set :eye_roles, -> { :app }
     set :eye_env, -> { {} }
 
+    set :chruby_map_bins, fetch(:chruby_map_bins, []).push(fetch(:eye_bin))
     set :rvm_map_bins, fetch(:rvm_map_bins, []).push(fetch(:eye_bin))
     set :rbenv_map_bins, fetch(:rbenv_map_bins, []).push(fetch(:eye_bin))
     set :bundle_bins, fetch(:bundle_bins, []).push(fetch(:eye_bin))


### PR DESCRIPTION
# Description
While trying to deploy [nucore-open](https://github.com/tablexi/nucore-open) using [chruby](https://github.com/postmodern/chruby) and [capistrano-chruby](https://github.com/capistrano/chruby) my deployment failed on the `eye:load_config` task. This is due to `eye-patch` using `bundle` instead of the `chruby-exec` required by `chruby`.

Adding this line fixes my deployments with `chruby`.

## Notes
In my testing I am using [v0.5.1](https://github.com/tablexi/eye-patch/releases/tag/v0.5.1) since that is the current version `nucore-open` is on. I only made this one line addition in that branch and it fixed my problem. I am opening this PR against master because as far as I can tell this should still be the proper fix for chruby support. I just wanted to be clear that I haven't tested this changed directly against `1.0.1`

Example of a failing build of nucore-open (using `eye-patch v0.5.1`): https://circleci.com/gh/joshea0/nucore-uconn/18

Example of a passing build of nucore-open (using this patch): https://circleci.com/gh/joshea0/nucore-uconn/33